### PR TITLE
Changed EPICS PV naming for ROC slow controls channels 

### DIFF
--- a/otsdaq-mu2e/TablePlugins/DTCInterfaceTable_table.cc
+++ b/otsdaq-mu2e/TablePlugins/DTCInterfaceTable_table.cc
@@ -142,7 +142,7 @@ unsigned int	DTCInterfaceTable::slowControlsHandlerConfig	(
 				        .getValue<std::string>();
 				__COUTV__(rocPluginType);
 
-				std::string location = fePair.first + "_" + rocChildPair.first;
+				std::string location = rocChildPair.first;
 
 				ConfigurationTree slowControlsLink = rocChildPair.second.getNode(
 				    rocColNames_.colLinkToSlowControlsChannelTable_);


### PR DESCRIPTION
Changed the `location` string for EPICS ROC PVs to use the ROC node name only, where it was previously concatenated with the parent DTC node name. This was inconsistent with the convention in otsdaq. 
 
To give a concrete example with a real PV name, this changes 

`Mu2e:TDAQ_crv:daq08DTC_crvROC09:ROC_p1_voltage` to `Mu2e:TDAQ_crv:crvROC09:ROC_p1_voltage`.